### PR TITLE
Improve detection of local site

### DIFF
--- a/pbd-livejs.php
+++ b/pbd-livejs.php
@@ -14,7 +14,7 @@
  * - http://twitter.com/mrtnkl
  */
 function pbd_livejs_script() {
-	if(is_user_logged_in() && ($_SERVER["SERVER_NAME"] == 'localhost' || $_SERVER["SERVER_NAME"] == '127.0.0.1')) {
+	if(is_user_logged_in() && ($_SERVER["SERVER_NAME"] == 'localhost' || $_SERVER["SERVER_NAME"] == '127.0.0.1' || $_SERVER["SERVER_ADDR"] == '127.0.0.1')) {
 		echo '<script type="text/javascript" src="'. plugins_url('js/live.js#css,js', __FILE__) .'"></script>';
 	}
 }


### PR DESCRIPTION
On my local machine, I edit my hosts file and create a VirtualHost entry in httpd-vhosts.conf, so SERVER_NAME is never localhost or 127.0.0.1 for me. This commit checks to see if SERVER_ADDR is 127.0.0.1, which is in fact true in my situation. I'm not certain this is the best method of detecting whether this is running on a 'local' site - thoughts?
